### PR TITLE
add pull-requests: read permission to verify-dockerfile workflow

### DIFF
--- a/.github/workflows/verify-dockerfile-refreshed-at-updated.yaml
+++ b/.github/workflows/verify-dockerfile-refreshed-at-updated.yaml
@@ -1,0 +1,14 @@
+name: Verify Dockerfile REFRESHED_AT Updated
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  verify-dockerfiles:
+    name: Verify Dockerfiles REFRESHED_AT Updated
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: senzing-factory/build-resources/.github/workflows/verify-dockerfile-refreshed-at-updated.yaml@v4


### PR DESCRIPTION
The verify-dockerfile-refreshed-at-updated reusable workflow needs pull-requests: read to function correctly with the callers permissions.