### PR TITLE
#51 Update to Senzing 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning].
 
 ### Changed in Unreleased
 
+## [4.2.2] - 2026-03-18
+
+### Changed in 4.2.2
+
+- Based on Senzing 4.2.2
+
 ## [4.2.1] - 2026-02-20
 
 ### Changed in 4.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=senzing/senzingsdk-runtime:4.2.1@sha256:b3af3bace2ae835e1de6ac10637e0ab3a9cf26b8803d22d32f26b8da12a74bed
+ARG BASE_IMAGE=senzing/senzingsdk-runtime:4.2.2@sha256:70356376f28800f9934940f9468315babf4337be9f7a532c0e3776f0f1cf4a66
 
 # Create the runtime image.
 
@@ -10,7 +10,7 @@ ARG SENZING_APT_INSTALL_TOOLS_PACKAGE="senzingsdk-tools"
 
 FROM ${BASE_IMAGE} AS builder
 
-ENV REFRESHED_AT=2026-02-20
+ENV REFRESHED_AT=2026-03-18
 
 # Run as "root" for system installation.
 
@@ -46,7 +46,7 @@ RUN pip3 install --no-cache-dir --upgrade pip \
 
 FROM ${BASE_IMAGE} AS runner
 
-ENV REFRESHED_AT=2026-02-20
+ENV REFRESHED_AT=2026-03-18
 
 ARG SENZING_APT_INSTALL_TOOLS_PACKAGE
 
@@ -54,7 +54,7 @@ ENV SENZING_APT_INSTALL_TOOLS_PACKAGE=${SENZING_APT_INSTALL_TOOLS_PACKAGE}
 
 LABEL Name="senzing/senzingsdk-tools" \
       Maintainer="support@senzing.com" \
-      Version="4.2.1"
+      Version="4.2.2"
 
 # Run as "root" for system installation.
 


### PR DESCRIPTION
## Summary
- Update base image to `senzing/senzingsdk-runtime:4.2.2`
- Bump `REFRESHED_AT` and `Version` label to reflect 4.2.2
- Add CHANGELOG entry for 4.2.2

Closes #51

---

Resolves #51