### PR TITLE
#53 CI maintenance: clean up cspell.json and Slack notification wiring

### DIFF
--- a/.github/workflows/docker-build-container.yaml
+++ b/.github/workflows/docker-build-container.yaml
@@ -46,8 +46,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
 
   docker-build-container-staging:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-push-containers-to-dockerhub.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub.yaml
@@ -9,8 +9,6 @@ permissions: {}
 
 jobs:
   docker-push-containers-to-dockerhub:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       attestations: write
       contents: write
@@ -46,10 +44,10 @@ jobs:
 
   slack-notification:
     needs: [docker-push-containers-to-dockerhub]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.outputs.status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.docker-push-containers-to-dockerhub.outputs.status }}
+      job-status: ${{ needs.docker-push-containers-to-dockerhub.result }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -10,10 +10,8 @@
     "Dockerfiles",
     "dockerhub",
     "docktermj",
-    "esbenp",
     "ICLA",
     "kernelsam",
-    "libpostal",
     "prettytable",
     "projectatomic",
     "psycopg",
@@ -25,13 +23,13 @@
     "senzingapi",
     "senzingsdk",
     "setuptools",
-    "stackoverflow",
     "testrun",
     "TOOLSDIRECTORY",
     "toplevel",
     "unixodbc",
-    "venv",
-    "yqqq"
+    "venv"
   ],
-  "ignorePaths": [".git/**"]
+  "ignorePaths": [
+    ".git/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove unused words from `.vscode/cspell.json`
- Use `needs.<job>.result` instead of `needs.<job>.outputs.status` for Slack notifications

Closes #53

---

Resolves #53